### PR TITLE
Dockerize the service + guide to readme + devnet.yml conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:16.04
+
+RUN apt-get update -y && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:webupd8team/java && \
+    apt-get install -y software-properties-common apt-transport-https python-software-properties debconf-utils && \
+    apt-get update -y && \
+    echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections && \
+    apt-get install -y oracle-java8-installer && \
+    apt-get install -y maven pwgen nginx
+
+WORKDIR /app
+ADD . /app

--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ ACES ARK to ETH transfer channel service
 
 ## Run Application
 
-```
-mvn spring-boot:run
-```
+1. Setup configuration in `application.yml`
+2. Start service: `mvn spring-boot:run`
+
+### Want to run via docker?
+
+1. Set correct environment variables in `docker-compose.yml`
+2. Start service: `docker-compose up`
 
 ## Using Service
 
@@ -92,7 +96,7 @@ curl -X POST localhost:9190/contracts \
   "arguments": {
     "recipientEthAddress": "0xcfd866733c2192311add9836f0e0cf50daba16a7"
   }
-}' 
+}'
 ```
 
 ```json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3'
+
+services:
+  ark-eth-channel:
+    build:
+      context: .
+    command: mvn spring-boot:run
+    environment:
+      EVENT_CALLBACK_URL: "http://localhost:9190/arkEvents"
+      APP_PORT: 9190
+      SERVICE_ETH_ADDRESS: "<your eth address that holds all the ETH>"
+      SERVICE_FLAT_FEE: 0
+      SERVICE_PERCENT_FEE: 1
+      ETH_RPC_URL: "http://localhost:8545"
+      ARK_MIN_CONFIRMATIONS: 5
+      ARK_LISTENER_URL: "http://<your-ark-listener>:9091"
+    volumes:
+      - ark-eth-channel:/app
+    expose:
+      - "9190"
+    ports:
+      - "9190:9190"
+
+volumes:
+  ark-eth-channel:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,20 +96,20 @@ serverInfo:
 arkNetworkConfigPath: "ark_network_config/testnet.yml"
 
 serviceEthAccount:
-  address: "change-me"
+  address: ${SERVICE_ETH_ADDRESS}
 
 fees:
-  arkFlatFee: 0
-  arkPercentFee: 1
+  arkFlatFee: ${SERVICE_FLAT_FEE}
+  arkPercentFee: ${SERVICE_PERCENT_FEE}
 
 server:
-  port: 9190
+  port: ${APP_PORT}
 
 arkListener:
-  url: "https://ark-listener-mainnet.arkaces.com/"
+  url: ${ARK_LISTENER_URL}
 
-arkEventCallbackUrl: "http://localhost:9190/arkEvents"
+arkEventCallbackUrl: ${EVENT_CALLBACK_URL}
 
-arkMinConfirmations: 5
+arkMinConfirmations: ${ARK_MIN_CONFIRMATIONS}
 
-ethRpcRootUri: "http://127.0.0.1:8545"
+ethRpcRootUri: ${ETH_RPC_URL}

--- a/src/main/resources/ark_network_config/devnet.yml
+++ b/src/main/resources/ark_network_config/devnet.yml
@@ -1,0 +1,12 @@
+scheme: http
+version: 1.0
+netHash: 578e820911f24e039733b45e4882b73e301f813a0d2c31330dafda84534ffa23
+pubKeyHash: 0x52
+seedPeers:
+  -
+    hostname: 167.99.243.111
+    port: 4002
+trustedPeers:
+  -
+    hostname: 167.99.243.111
+    port: 4002


### PR DESCRIPTION
**Changes:**
- option to build service using Docker
- added devnet.yml config

**Why this change?**
It's easier to start, you just run `docker-compose up` and it builds everything. It would be good to upload final images to hub.docker.com so that if you're setting up a service you could do it something like:

example-docker-compose.yml:
```
version: '3'

services:
  ark-eth-channel:
    image: aces/ark-eth-channel
    environment:
      EVENT_CALLBACK_URL: "http://ark-eth-channel:9190/arkEvents"
      APP_PORT: 9190
      SERVICE_ETH_ADDRESS: "<your eth address that holds all the ETH>"
      SERVICE_FLAT_FEE: 0
      SERVICE_PERCENT_FEE: 1
      ETH_RPC_URL: "http://123.12.34.45:8545"
      ARK_MIN_CONFIRMATIONS: 5
      ARK_LISTENER_URL: "https://ark-listener:9091"
    expose:
      - "9190"
    ports:
      - "9190:9190"

  ark-listener:
    image: aces/ark-listener
    expose:
      - "9091"
    ports:
      - "9091:9091"

volumes:
  ark-eth-channel:
```

Where you'd run `docker-compose up` and have everything ready streight away. Some modifications are needed in the listener tho.